### PR TITLE
api(console.count): remove the "same line" requirement

### DIFF
--- a/api.md
+++ b/api.md
@@ -52,7 +52,29 @@ test();
   Login called for paul: 2
 ```
 
-#### `console.debug(object [,object, ...])` 
+
+If no label is provided then the script url and line number of the `console.count` statement is used for associating the counter with `console.count` invocation.
+
+In the following example count() is invoked without a label from two different functions.
+```javascript
+function test1() {
+  console.count();
+}
+
+function test2() {
+  console.count();
+}
+
+test1();
+test2();
+test1();
+
+> : 1            test-script.js:3
+  : 1            test-script.js:7
+  : 2            test-script.js:3
+```
+
+#### `console.debug(object [,object, ...])`
 
 This method is an alias for to [`console.log()`](#consolelogobject--object-).
 


### PR DESCRIPTION
None of Firefox, Chrome or Safari currently keeps a per line counter. Only the passed in string is used as a counter identifier. 

The currently spec-ed out behavior is not desirable or useful in practice.
