### PR TITLE
Add reference to console comparison doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Three recent efforts to document current support for console APIs:
 ![image](https://f.cloud.github.com/assets/39191/1274955/b7d40fcc-2dda-11e3-94c0-3357433fc90a.png)
 </a>
 
-[Console API Comparison](https://docs.google.com/document/d/1rtCIorwj4veWN2_wCVQqkitx2V1GSRxmuKByQtmUCr8/edit?usp=sharing) by the IE f12 tools team
+[Console API Comparison](https://docs.google.com/document/d/1rtCIorwj4veWN2_wCVQqkitx2V1GSRxmuKByQtmUCr8/edit?usp=sharing) by the IE F12 tools team
 <a href="https://docs.google.com/document/d/1rtCIorwj4veWN2_wCVQqkitx2V1GSRxmuKByQtmUCr8/edit?usp=sharing">
 ![image](http://i.gyazo.com/ac9392e70ceb150430c3df72fd070ded.png)
 </a>

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ console.assert(a + b, "Uh oh!");
 
 ### Browser support
 
-Two recent efforts to document current support for console APIs:
+Three recent efforts to document current support for console APIs:
 
 [dev tools console api support](https://docs.google.com/spreadsheet/ccc?key=0ArzNE_OHjXkQdF9FTjF4ZlQzYWREUHplUlNPcXNpb2c&usp=drive_web#gid=0) by the Firebug Working Group
 
@@ -109,6 +109,11 @@ Two recent efforts to document current support for console APIs:
 
 <a href="http://www.2ality.com/2013/10/console-api.html">
 ![image](https://f.cloud.github.com/assets/39191/1274955/b7d40fcc-2dda-11e3-94c0-3357433fc90a.png)
+</a>
+
+[Console API Comparison](https://docs.google.com/document/d/1rtCIorwj4veWN2_wCVQqkitx2V1GSRxmuKByQtmUCr8/edit?usp=sharing) by the IE f12 tools team
+<a href="https://docs.google.com/document/d/1rtCIorwj4veWN2_wCVQqkitx2V1GSRxmuKByQtmUCr8/edit?usp=sharing">
+![image](http://i.gyazo.com/ac9392e70ceb150430c3df72fd070ded.png)
 </a>
 
 


### PR DESCRIPTION
Thought it might be handy to share a [document] (https://docs.google.com/document/d/1rtCIorwj4veWN2_wCVQqkitx2V1GSRxmuKByQtmUCr8/edit) that we use to keep track of the status of the various console related features. It's not been looked at since November though but should still be useful and largely relevent.