### PR TITLE
Document behavior with multiple %c formatters in console.log

### DIFF
--- a/api.md
+++ b/api.md
@@ -212,6 +212,7 @@ The functions supporting these specifiers are [`console.debug()`](#consoledebugo
 | `%c`              | Formats the output string according to CSS styles you provide                      |
 
 * Firebug supports limiting the number of decimal places via `%.xf`, where `x` is the number of decimal places.
+* When multiple `%c` specifiers are included next to each other with no space, then the last style should be used.  For example: `console.log("%c%chi", "color: green", "background: red"); // Should use "background: red"`
 
 ```javascript
 console.log("Hello %s", "Brian");


### PR DESCRIPTION
Adding a note about this case with %c formatting after the fix in https://bugzilla.mozilla.org/show_bug.cgi?id=1200551, specifically https://bugzilla.mozilla.org/show_bug.cgi?id=1200551#c10.  I've tested latest Chrome, Safari, Firebug, and Firefox (after the fix) and they all conform to this behavior.  IE doesn't support %c formatters.